### PR TITLE
Update RailoAjax.js

### DIFF
--- a/src/tag/railo/core/ajax/js/RailoAjax.js
+++ b/src/tag/railo/core/ajax/js/RailoAjax.js
@@ -1026,7 +1026,7 @@ Railo.ajaxProxy.invokeMethod = function(o,m,a){
 				arg[k2] = a[k][k2];
 			}
 		}else{
-			if (a[k]) {
+			if (a[k] || a[k] === 0 || a[k] === "" ) {
 				arg[k] = a[k];
 			}
 		}
@@ -1412,7 +1412,7 @@ Railo.Json = (function(){
 	    }
 	
 	    var cx = /[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
-	        escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,
+	        escapable = /[\\\"\x00-\x1f\x7f-\x9f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff\u0026\u002B]/g,
 	        gap,
 	        indent,
 	        meta = {    


### PR DESCRIPTION
1) function "Railo.Json"
variable "escapable" now includes the chars "&" and "+"

2) function "Railo.ajaxProxy.invokeMethod"
test:
if (a[k])
changed to:
if (a[k] || a[k] === 0 || a[k] === "" )
to include params that equal 0 and ""
